### PR TITLE
fix: add semicolon to fix highlight bug

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -144,7 +144,7 @@
   --text-faint: var(--secondary);
   --text-error: #800000;
   --text-error-hover: #990000;
-  --text-highlight-bg: var(--surface-variant)
+  --text-highlight-bg: var(--surface-variant);
   --text-highlight-bg-active: rgba(255, 128, 0, 0.4);
   --text-selection: rgba(204, 230, 255, 0.99);
   --text-on-accent: #f2f2f2;
@@ -263,7 +263,7 @@
   --text-faint: #666;
   --text-error: #cf6679;
   --text-error-hover: #990000;
-  --text-highlight-bg: var(--surface-variant)
+  --text-highlight-bg: var(--surface-variant);
   --text-highlight-bg-active: rgba(255, 128, 0, 0.4);
   --text-selection: rgba(23, 48, 77, 0.99);
   --text-on-accent: #dcddde;

--- a/scss/_vars.scss
+++ b/scss/_vars.scss
@@ -161,7 +161,7 @@
   --text-faint: var(--secondary);
   --text-error: #800000;
   --text-error-hover: #990000;
-  --text-highlight-bg: var(--surface-variant)
+  --text-highlight-bg: var(--surface-variant);
   --text-highlight-bg-active: rgba(255, 128, 0, 0.4);
   --text-selection: rgba(204, 230, 255, 0.99);
   --text-on-accent: #f2f2f2;
@@ -296,7 +296,7 @@
   --text-faint: #666;
   --text-error: #cf6679;
   --text-error-hover: #990000;
-  --text-highlight-bg: var(--surface-variant)
+  --text-highlight-bg: var(--surface-variant);
   --text-highlight-bg-active: rgba(255, 128, 0, 0.4);
   --text-selection: rgba(23, 48, 77, 0.99);
   --text-on-accent: #dcddde;


### PR DESCRIPTION
- Fixed css/scss syntax by adding some missing `;` for highlight background to show
- Resolved https://github.com/selfire1/obsidian-you-theme/issues/16

Before | After
-|-
<img width="779" alt="Before" src="https://user-images.githubusercontent.com/25860320/190332206-445b58f0-bab1-492c-b8b0-2b37b2dee0a3.png">|<img width="779" alt="After" src="https://user-images.githubusercontent.com/25860320/190332226-4c0095f3-e44c-40b5-a14e-82167a261e9e.png">

> Note: I really enjoyed this Obsidian theme! I rely on search/highlight a lot so wanted to make it better for other users too.